### PR TITLE
Fix 3D model iterator crash

### DIFF
--- a/magnify/README.md
+++ b/magnify/README.md
@@ -2,7 +2,7 @@
 
 Adds a magnifying glass tool and inventory plant compenium for viewing information about various plant species in the MineTest world
 
-*Version: v0.10.1*  
+*Version: v0.10.2*  
 *Dependencies: [`sfinv`](https://github.com/rubenwardy/sfinv)*
 
 ## API

--- a/magnify/init.lua
+++ b/magnify/init.lua
@@ -628,7 +628,7 @@ end
 --- @return table
 local function read_obj_textures(target_obj)
     local textures = {}
-    local model_iter = io.lines(target_obj, "r")
+    local model_iter = io.lines(target_obj)
     local line = model_iter()
     while line do 
         local match = string.match(line, "^g (.*)")

--- a/magnify/mod.conf
+++ b/magnify/mod.conf
@@ -2,4 +2,4 @@ name = magnify
 description = Adds a magnifying glass tool and plant compendium for viewing information about plant species in the Minetest world
 depends = sfinv
 optional_depends = mc_toolhandler
-version = 0.10.1-build.1
+version = 0.10.2-build.1


### PR DESCRIPTION
Fixes a crash on Minetest 5.7.0 caused by an invalid 3D model iterator function

This PR appears to be compatible with Minetest 5.5.1 and 5.6.0